### PR TITLE
fixed post_frame method

### DIFF
--- a/src/fluepdot/fluepdot.py
+++ b/src/fluepdot/fluepdot.py
@@ -91,15 +91,18 @@ class Fluepdot:
 
 
     def post_frame(self, frame: List[List[bool]]) -> Response:
-        data: List[List[str]] = [[" "] * width for _ in range(height)]
-        for x, l in frame:
-            for y, b in l:
+        data: List[List[str]] = [[" "] * self.width for _ in range(self.height)]
+        for x, l in enumerate(frame):
+            for y, b in enumerate(l):
                 if b:
                     try:
-                        data[x, y] = "X"
+                        data[x][y] = "X"
                     except IndexError as e:
                         print(e)
-        return self._post(frameURL, post=data)
+        outStr = ""
+        for line in data:
+            outStr = outStr + "".join(line) + "\n"
+        return self._post(frameURL, post=outStr)
 
 
     def set_pixel(x: int = 0, y: int = 0) -> Response:


### PR DESCRIPTION
The method `post_frame` didn't work, cause the for-loop syntax wasn't working with python 3.11. Added the `enumerate()` to both for loops. Then also the syntax of writing `'X'` in the `data` list wasn't working, so I changed it. The data sent with the `post`-request should be a string, but was a list, so I added a simple for-loop that joined the list into a string.

Thanks for the awesome library, I'm very happy flipping fluepdots :)